### PR TITLE
"snooz" -> "snooze"

### DIFF
--- a/_posts/2014-07-12-alarm_clocks.md
+++ b/_posts/2014-07-12-alarm_clocks.md
@@ -6,7 +6,7 @@ date:   2014-07-12 16:05:21
 
 [![Telechron 7H241 Snooz-Alarm]({{ site.url }}/images/clocks/telechron.jpg)](http://www.telechron.net/eod/7h241.htm)
 
-In 1956 General Electric introduced the *Telechron 7H241 Snooz-Alarm*[^telechron].  Like no alarm clock before it, the Telechron introduced a "snooz" button that, when pressed, would silence the alarm for several minutes before reactivating it, allowing the user to gain several more minutes of sleep. This feature was first copied three years later, but using the name "drowse" instead of snooze[^westclox]. Today, almost all alarm clocks provide a snooze function of this kind; GE's term evidently became the widely accepted one. 
+In 1956 General Electric introduced the *Telechron 7H241 Snooz-Alarm*[^telechron].  Like no alarm clock before it, the Telechron introduced a "snooze" button that, when pressed, would silence the alarm for several minutes before reactivating it, allowing the user to gain several more minutes of sleep. This feature was first copied three years later, but using the name "drowse" instead of snooze[^westclox]. Today, almost all alarm clocks provide a snooze function of this kind; GE's term evidently became the widely accepted one. 
 
 As on the Telechron, the "snooze" function on today's alarm clocks is activated by a larger and easier to press button than the "alarm off" function. Presumably, this design was chosen so that the person being woken (who is probably very drowsy) will be more likely to hit the snooze button (and thus be woken again in several minutes) than the alarm off button (and thus sleep for several extra hours and be really late).
 


### PR DESCRIPTION
Because although the alarm clock is called snooz, the button has an e.

http://www.telechron.net/eod/pics/7h241b.jpg
